### PR TITLE
Add support for custom http code for deny and denyWhen

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ return $this->authorize($user, 'update', $post)
     ->deny();
 ```
 
+### Custom Http status
+
+You can deny the policy returning a custom http status code :
+
+```php
+return $this->denyWithStatusWhen($post->user_id !== $user->id, 404)
+        ->allow();
+// or $this->>allowWhen(...)->denyWithStatus(404);
+```
+
+In the case of `404` status code, you can use the shortcut
+
+```php
+return $this->denyAsNotFoundWhen($post->user_id !== $user->id)
+        ->allow();
+// or $this->>allowWhen(...)->denyAsNotFound();
+```
+
 ### Lazy evaluation
 
 The different branches `allowWhen` and `denyWhen` are evaluated lazily which mean that the following code is completely

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.0",
-        "illuminate/auth": "^9.0"
+        "illuminate/contracts": "^9.20",
+        "illuminate/auth": "^9.20"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.7",

--- a/src/FluentPolicy.php
+++ b/src/FluentPolicy.php
@@ -19,6 +19,16 @@ abstract class FluentPolicy
         return $this->when($when, $this->deny($message, $code));
     }
 
+    protected function denyWithStatusWhen(bool $when, int $status, ?string $message = null, ?int $code = null): self
+    {
+        return $this->when($when, $this->denyWithStatus($status, $message, $code));
+    }
+
+    protected function denyAsNotFoundWhen(bool $when, ?string $message = null, ?int $code = null): self
+    {
+        return $this->when($when, $this->denyAsNotFound($message, $code));
+    }
+
     protected function when(bool $when, Response $response): self
     {
         throw_if($when, EarlyReturn::class, $response);
@@ -34,6 +44,16 @@ abstract class FluentPolicy
     protected function deny(?string $message = null, ?int $code = null): Response
     {
         return Response::deny($message, $code);
+    }
+
+    protected function denyWithStatus(int $status, ?string $message = null, ?int $code = null): Response
+    {
+        return Response::denyWithStatus($status, $message, $code);
+    }
+
+    protected function denyAsNotFound(?string $message = null, ?int $code = null): Response
+    {
+        return Response::denyAsNotFound($message, $code);
     }
 
     protected function otherwise(Response $response): Response

--- a/src/Phpstan/WhenMethodTypeSpecifyingExtension.php
+++ b/src/Phpstan/WhenMethodTypeSpecifyingExtension.php
@@ -29,7 +29,11 @@ class WhenMethodTypeSpecifyingExtension implements MethodTypeSpecifyingExtension
         MethodCall $node,
         TypeSpecifierContext $context,
     ): bool {
-        return in_array($methodReflection->getName(), ['denyWhen', 'allowWhen', 'when']);
+        return in_array(
+            $methodReflection->getName(),
+            ['denyWhen', 'denyWithStatusWhen', 'denyAsNotFoundWhen', 'allowWhen', 'when'],
+            true
+        );
     }
 
     public function specifyTypes(

--- a/tests/FluentPolicyTest.php
+++ b/tests/FluentPolicyTest.php
@@ -98,6 +98,56 @@ it('denies the action', function (FluentPolicy $policy): void {
     },
 ]);
 
+it('denies the action with custom status', function (FluentPolicy $policy): void {
+    expect(inspect($policy))
+        ->allowed()->toBeFalse()
+        ->status()->toBe(405);
+})->with([
+    'silly' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->denyWithStatus(405);
+        }
+    },
+    'fallback' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->allowWhen(false)->denyWithStatus(405);
+        }
+    },
+    'simple' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->denyWithStatusWhen(true, 405)->allow();
+        }
+    },
+]);
+
+it('denies the action as not found', function (FluentPolicy $policy): void {
+    expect(inspect($policy))
+        ->allowed()->toBeFalse()
+        ->status()->toBe(404);
+})->with([
+    'silly' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->denyAsNotFound();
+        }
+    },
+    'fallback' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->allowWhen(false)->denyAsNotFound();
+        }
+    },
+    'simple' => new class() extends FluentPolicy {
+        public function run(): Response
+        {
+            return $this->denyAsNotFoundWhen(true)->allow();
+        }
+    },
+]);
+
 it('customises the response', function (): void {
     expect(inspect(
         new class() extends FluentPolicy {


### PR DESCRIPTION
Adds ability to define custom http code for deny as Laravel 9.20+ now supports it

See https://laravel.com/docs/9.x/authorization#customising-policy-response-status